### PR TITLE
Update Serilog.Enrichers.GlobalLogContext build process to use Cake v2.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.3.0",
+      "version": "2.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
-#addin "nuget:?package=Cake.MinVer&version=1.0.1"
-#addin "nuget:?package=Cake.Args&version=1.0.1"
+#addin "nuget:?package=Cake.MinVer&version=2.0.0"
+#addin "nuget:?package=Cake.Args&version=2.0.0"
 
 var target       = ArgumentOrDefault<string>("target") ?? "pack";
 var buildVersion = MinVer(s => s.WithTagPrefix("v").WithDefaultPreReleasePhase("preview"));
@@ -15,7 +15,7 @@ Task("restore")
     .IsDependentOn("clean")
     .Does(() =>
 {
-    DotNetCoreRestore("./serilog-enrichers-globallogcontext.sln", new DotNetCoreRestoreSettings
+    DotNetRestore("./serilog-enrichers-globallogcontext.sln", new DotNetRestoreSettings
     {
         LockedMode = true,
     });
@@ -25,12 +25,12 @@ Task("build")
     .IsDependentOn("restore")
     .DoesForEach(new[] { "Debug", "Release" }, (configuration) =>
 {
-    DotNetCoreBuild("./serilog-enrichers-globallogcontext.sln", new DotNetCoreBuildSettings
+    DotNetBuild("./serilog-enrichers-globallogcontext.sln", new DotNetBuildSettings
     {
         Configuration = configuration,
         NoRestore = true,
         NoIncremental = false,
-        MSBuildSettings = new DotNetCoreMSBuildSettings
+        MSBuildSettings = new DotNetMSBuildSettings
         {
             Version = buildVersion.Version,
             AssemblyVersion = buildVersion.AssemblyVersion,
@@ -44,7 +44,7 @@ Task("test")
     .IsDependentOn("build")
     .Does(() =>
 {
-    var settings = new DotNetCoreTestSettings
+    var settings = new DotNetTestSettings
     {
         Configuration = "Release",
         NoRestore = true,
@@ -54,7 +54,7 @@ Task("test")
     var projectFiles = GetFiles("./test/**/*.csproj");
     foreach (var file in projectFiles)
     {
-        DotNetCoreTest(file.FullPath, settings);
+        DotNetTest(file.FullPath, settings);
     }
 });
 
@@ -64,13 +64,13 @@ Task("pack")
 {
     var releaseNotes = $"https://github.com/serilog-contrib/serilog-enrichers-globallogcontext/releases/tag/v{buildVersion.Version}";
 
-    DotNetCorePack("./src/Serilog.Enrichers.GlobalLogContext/Serilog.Enrichers.GlobalLogContext.csproj", new DotNetCorePackSettings
+    DotNetPack("./src/Serilog.Enrichers.GlobalLogContext/Serilog.Enrichers.GlobalLogContext.csproj", new DotNetPackSettings
     {
         Configuration = "Release",
         NoRestore = true,
         NoBuild = true,
         OutputDirectory = "./artifact/nuget",
-        MSBuildSettings = new DotNetCoreMSBuildSettings
+        MSBuildSettings = new DotNetMSBuildSettings
         {
             Version = buildVersion.Version,
             PackageReleaseNotes = releaseNotes,
@@ -96,7 +96,7 @@ Task("push")
         return;
     }
 
-    var nugetPushSettings = new DotNetCoreNuGetPushSettings
+    var nugetPushSettings = new DotNetNuGetPushSettings
     {
         Source = url,
         ApiKey = apiKey,
@@ -104,7 +104,7 @@ Task("push")
 
     foreach (var nugetPackageFile in GetFiles("./artifact/nuget/*.nupkg"))
     {
-        DotNetCoreNuGetPush(nugetPackageFile.FullPath, nugetPushSettings);
+        DotNetNuGetPush(nugetPackageFile.FullPath, nugetPushSettings);
     }
 });
 


### PR DESCRIPTION
Closes #10
